### PR TITLE
Update a bunch of ccalls

### DIFF
--- a/src/Ccluster.jl
+++ b/src/Ccluster.jl
@@ -658,9 +658,9 @@ PGLOBALCCLUSTERFMPQ = fmpq_poly(0);
 
 function getApp_FMPQ( dest::Ref{acb_poly}, prec::Int )
 # function getApp_FMPQ( dest::acb_poly, prec::Int )
-#     ccall((:acb_poly_set_fmpq_poly, :libarb), Nothing,
+#     ccall((:acb_poly_set_fmpq_poly, libarb), Nothing,
 #                 (Ref{acb_poly}, Ref{fmpq_poly}, Int), dest, PGLOBALCCLUSTERFMPQ, prec)
-    ccall((:acb_poly_set_fmpq_poly, :libarb), Cvoid,
+    ccall((:acb_poly_set_fmpq_poly, libarb), Cvoid,
                 (Ref{acb_poly}, Ref{fmpq_poly}, Int), dest, PGLOBALCCLUSTERFMPQ, prec)
 end
 

--- a/src/Tcluster.jl
+++ b/src/Tcluster.jl
@@ -358,8 +358,8 @@ end
 # approximation function
 function getAppFirst( dest::Ptr{acb_poly}, prec::Int )::Cvoid
     global TCLUSTER_POLS
-#     ccall((:acb_poly_set_fmpq_poly, :libarb), 
-    ccall((:compApp_poly_set_fmpq_poly, :libccluster), 
+#     ccall((:acb_poly_set_fmpq_poly, libarb), 
+    ccall((:compApp_poly_set_fmpq_poly, libccluster), 
             Cvoid, (Ptr{acb_poly}, Ref{fmpq_poly}, Int), 
                    dest,           TCLUSTER_POLS[1][1],            prec)
 end
@@ -568,8 +568,8 @@ function getAppSys( dest::Ptr{acb_poly}, prec::Int )::Cvoid
     Ptemp = TCLUSTER_POLS[1][actualPol]
     
     if actualPol==1 #should never enter here
-#         ccall((:acb_poly_set_fmpq_poly, :libarb), 
-        ccall((:compApp_poly_set_fmpq_poly, :libccluster),
+#         ccall((:acb_poly_set_fmpq_poly, libarb), 
+        ccall((:compApp_poly_set_fmpq_poly, libccluster),
             Cvoid, (Ptr{acb_poly}, Ref{fmpq_poly}, Int), 
                    dest,           Ptemp,            prec)
     else
@@ -615,8 +615,8 @@ function getAppSys( dest::Ptr{acb_poly}, prec::Int )::Cvoid
         approx::Array{acb,1} = Ccluster.getApproximation(TCLUSTER_CFEV[1],prec)
         Ptemp2::acb_poly = Ccluster.getPolAtHorner(Ptemp,approx,prec)
         
-#         ccall((:acb_poly_set, :libarb), 
-        ccall((:compApp_poly_set, :libccluster), 
+#         ccall((:acb_poly_set, libarb), 
+        ccall((:compApp_poly_set, libccluster), 
             Cvoid, (Ptr{acb_poly}, Ref{acb_poly}, Int), 
                    dest,          Ptemp2,         prec)
                    

--- a/src/algClus.jl
+++ b/src/algClus.jl
@@ -187,7 +187,7 @@ end
 # Rx, x = PolynomialRing(QQ, "x")
 # P = x^2 - fmpq(2)
 # function getApproximation( dest::Ptr{acb_poly}, prec::Int )
-#     ccall((:acb_poly_set_fmpq_poly, :libarb), 
+#     ccall((:acb_poly_set_fmpq_poly, libarb), 
 #       Cvoid, (Ptr{acb_poly}, Ref{fmpq_poly}, Int), 
 #              dest,          P,            prec)
 # end

--- a/src/box.jl
+++ b/src/box.jl
@@ -66,10 +66,10 @@ mutable struct box
 #     function box(re::fmpq, im::fmpq, width::fmpq, nbSols::Int)
 #         z = new()
 #         
-#         ccall( (:compBox_init, :libccluster), 
+#         ccall( (:compBox_init, libccluster), 
 #              Nothing, (Ref{box},), 
 #                     &z)
-#         ccall( (:compBox_set_3realRat_int, :libccluster), 
+#         ccall( (:compBox_set_3realRat_int, libccluster), 
 #              Nothing, (Ref{box}, Ref{fmpq}, Ref{fmpq}, Ref{fmpq}, Int), 
 #                     &z,        &re,       &im,       &width,   nbSols)
 #         finalizer(z, _box_clear_fn)

--- a/src/triangularSys.jl
+++ b/src/triangularSys.jl
@@ -51,8 +51,8 @@ function evalUniFMPQPol(P::fmpq_poly, b::acb, prec::Int)::acb
     CC::AcbField = ComplexField(prec)
     R::AcbPolyRing, dummy::acb_poly = PolynomialRing(CC, "dummy")
     res::acb_poly = R(0)
-#     ccall((:acb_poly_set_fmpq_poly, :libarb), 
-    ccall((:compApp_poly_set_fmpq_poly, :libccluster), 
+#     ccall((:acb_poly_set_fmpq_poly, libarb), 
+    ccall((:compApp_poly_set_fmpq_poly, libccluster), 
       Cvoid, (Ref{acb_poly}, Ref{fmpq_poly}, Int), 
               res,           P,             prec)
     return evaluate(res, CC(b))
@@ -77,8 +77,8 @@ end
 
 function evalPolAtHorner(P::fmpq_poly, b::Array{acb, 1}, prec::Int, field::AcbField, ring::AcbPolyRing)::acb
     poly::acb_poly = ring(0)
-#     ccall((:acb_poly_set_fmpq_poly, :libarb), 
-    ccall((:compApp_poly_set_fmpq_poly, :libccluster), 
+#     ccall((:acb_poly_set_fmpq_poly, libarb), 
+    ccall((:compApp_poly_set_fmpq_poly, libccluster), 
             Cvoid, (Ref{acb_poly}, Ref{fmpq_poly}, Int), 
                     poly,          P,              prec)
     return evaluate(poly, b[1])
@@ -91,8 +91,8 @@ function evalPolAtHorner(P::Generic.Poly{fmpq_poly},
     temp::acb_poly = ring(0)
     while deg>=0
     
-#         ccall((:acb_poly_set_fmpq_poly, :libarb), 
-        ccall((:compApp_poly_set_fmpq_poly, :libccluster), 
+#         ccall((:acb_poly_set_fmpq_poly, libarb), 
+        ccall((:compApp_poly_set_fmpq_poly, libccluster), 
                 Cvoid, (Ref{acb_poly}, Ref{fmpq_poly},      Int), 
                         temp,          coeff(P,deg), prec)
         
@@ -117,8 +117,8 @@ function evalPolAtHorner(P::Generic.Poly{Generic.Poly{fmpq_poly}},
     while deg>=0
         
         while deg2>=0
-#             ccall((:acb_poly_set_fmpq_poly, :libarb), 
-            ccall((:compApp_poly_set_fmpq_poly, :libccluster), 
+#             ccall((:acb_poly_set_fmpq_poly, libarb), 
+            ccall((:compApp_poly_set_fmpq_poly, libccluster), 
                     Cvoid, (Ref{acb_poly}, Ref{fmpq_poly},      Int), 
                            temp,           coeff(P2,deg2), prec)
             res2 = evaluate(temp, b[1]) + b[2]*res2
@@ -161,8 +161,8 @@ function evalPolAtHorner(P::Generic.Poly{Generic.Poly{Generic.Poly{fmpq_poly}}},
         while deg2>=0
             
             while deg3>=0
-#                 ccall((:acb_poly_set_fmpq_poly, :libarb), 
-                ccall((:compApp_poly_set_fmpq_poly, :libccluster), 
+#                 ccall((:acb_poly_set_fmpq_poly, libarb), 
+                ccall((:compApp_poly_set_fmpq_poly, libccluster), 
                         Cvoid, (Ref{acb_poly}, Ref{fmpq_poly},      Int), 
                                temp,           coeff(P3,deg3), prec)
                         res3 = evaluate(temp, b[1]) + b[2]*res3
@@ -279,7 +279,7 @@ end
 #     temp::acb_poly = R(0)
 #     for index=0:degree(P)
 #         
-#         ccall((:acb_poly_set_fmpq_poly, :libarb), 
+#         ccall((:acb_poly_set_fmpq_poly, libarb), 
 #                 Cvoid, (Ref{acb_poly}, Ref{fmpq_poly},      Int), 
 #                         temp,          coeff(P,index), prec)
 #                         
@@ -305,7 +305,7 @@ end
 #     temp::acb_poly = R(0)
 #     while deg>=0
 #         
-#         ccall((:acb_poly_set_fmpq_poly, :libarb), 
+#         ccall((:acb_poly_set_fmpq_poly, libarb), 
 #             Cvoid, (Ref{acb_poly}, Ref{fmpq_poly},      Int), 
 #                     temp,          coeff(P,deg), prec)
 #                     
@@ -333,7 +333,7 @@ end
 #         res2::acb = CC(0)
 #         temp2::acb_poly = R(0)
 #         while deg2>=0
-#             ccall((:acb_poly_set_fmpq_poly, :libarb), 
+#             ccall((:acb_poly_set_fmpq_poly, libarb), 
 #                     Cvoid, (Ref{acb_poly}, Ref{fmpq_poly},      Int), 
 #                            temp2,           coeff(P2,deg2), prec)
 #             res2 = evaluate(temp2, b[1]) + b[2]*res2
@@ -372,7 +372,7 @@ end
 #             
 #             while deg3>=0
 #                 
-#                 ccall((:acb_poly_set_fmpq_poly, :libarb), 
+#                 ccall((:acb_poly_set_fmpq_poly, libarb), 
 #                     Cvoid, (Ref{acb_poly}, Ref{fmpq_poly},      Int), 
 #                            temp3,           coeff(P3,deg3), prec)
 #                 res3 = evaluate(temp3, b[1]) + b[2]*res3
@@ -424,7 +424,7 @@ end
 #                 
 #                 while deg4>=0
 #                 
-#                     ccall((:acb_poly_set_fmpq_poly, :libarb), 
+#                     ccall((:acb_poly_set_fmpq_poly, libarb), 
 #                            Cvoid, (Ref{acb_poly}, Ref{fmpq_poly},      Int), 
 #                                    temp4,           coeff(P4,deg4), prec)
 #                            res4 = evaluate(temp4, b[1]) + b[2]*res4

--- a/test_devel/testSymbolicTSG.jl
+++ b/test_devel/testSymbolicTSG.jl
@@ -11,7 +11,7 @@ for k = 0:n
 end
 
 # function getAppBern( dest::Ptr{acb_poly}, prec::Int )
-#     ccall((:acb_poly_set_fmpq_poly, :libarb), Void,
+#     ccall((:acb_poly_set_fmpq_poly, libarb), Void,
 #                 (Ptr{acb_poly}, Ptr{fmpq_poly}, Int), dest, &P, prec)
 # end
 


### PR DESCRIPTION
When using JLLs, the shared library should be addressed by the global
object `libarb` resp. `libccluster`, not by a symbol. Indeed, the later
does not work in certain situations (depending on the Julia version and OS)
